### PR TITLE
Fix eslint error

### DIFF
--- a/muppet.js
+++ b/muppet.js
@@ -2,7 +2,7 @@
 
 const puppeteer = require('puppeteer');
 
-async function sleep(delay) {
+async function sleep (delay) {
   return new Promise(resolve => setTimeout(resolve, delay));
 }
 


### PR DESCRIPTION
```
muppet/muppet.js
  5:21  error  Missing space before function parentheses
  space-before-function-paren

  ✖ 1 problem (1 error, 0 warnings)
    1 error and 0 warnings potentially fixable with the `--fix` option.
```